### PR TITLE
fixed :default_comparison_function spelling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+.elixir_ls/

--- a/lib/prioqueue.ex
+++ b/lib/prioqueue.ex
@@ -110,7 +110,7 @@ defmodule Prioqueue do
   """
   def empty(opts \\ []) do
     implementation = Keyword.get(opts, :implementation, Application.get_env(:prioqueue, :default_implementation, Prioqueue.Implementations.SkewHeap))
-    cmp_fun = Keyword.get(opts, :cmp_fun, Application.get_env(:prioqueue, :default__comparison_function, &Prioqueue.Helper.cmp/2))
+    cmp_fun = Keyword.get(opts, :cmp_fun, Application.get_env(:prioqueue, :default_comparison_function, &Prioqueue.Helper.cmp/2))
     implementation.empty(cmp_fun: cmp_fun)
   end
 

--- a/test/prioqueue_test.exs
+++ b/test/prioqueue_test.exs
@@ -61,6 +61,23 @@ defmodule PrioqueueTest do
       assert (simple_prioqueue(unquote(impl)) |> Prioqueue.member?(1))
     end
 
+    test "#{impl} :default_comparison_function?" do
+      # temporarily set the cmp_inverse in the application
+      Application.put_env(:prioqueue, :default_comparison_function, &Prioqueue.Helper.cmp_inverse/2)
+
+      pqueue_inverse_app = Enum.into([1, 3, 2], Prioqueue.empty(implementation: unquote(impl)))
+
+      # restore the default
+      Application.put_env(:prioqueue, :default_comparison_function, &Prioqueue.Helper.cmp/2)
+
+      assert Enum.map(pqueue_inverse_app,fn x -> x end) == [3, 2, 1]
+    end
+
+    test "#{impl} cmp_fun?" do
+      pqueue_inverse = Enum.into([1, 3, 2], Prioqueue.empty(implementation: unquote(impl), cmp_fun: &Prioqueue.Helper.cmp_inverse/2))
+      assert Enum.map(pqueue_inverse,fn x -> x end) == [3, 2, 1]
+    end
+
   end
   def simple_prioqueue(impl) do
     Prioqueue.empty(implementation: impl)

--- a/test/prioqueue_test.exs
+++ b/test/prioqueue_test.exs
@@ -61,7 +61,7 @@ defmodule PrioqueueTest do
       assert (simple_prioqueue(unquote(impl)) |> Prioqueue.member?(1))
     end
 
-    test "#{impl} :default_comparison_function?" do
+    test "#{impl} :default_comparison_function" do
       # temporarily set the cmp_inverse in the application
       Application.put_env(:prioqueue, :default_comparison_function, &Prioqueue.Helper.cmp_inverse/2)
 
@@ -73,7 +73,7 @@ defmodule PrioqueueTest do
       assert Enum.map(pqueue_inverse_app,fn x -> x end) == [3, 2, 1]
     end
 
-    test "#{impl} cmp_fun?" do
+    test "#{impl} cmp_fun" do
       pqueue_inverse = Enum.into([1, 3, 2], Prioqueue.empty(implementation: unquote(impl), cmp_fun: &Prioqueue.Helper.cmp_inverse/2))
       assert Enum.map(pqueue_inverse,fn x -> x end) == [3, 2, 1]
     end


### PR DESCRIPTION
the documentation says it's `:default_comparison_function`, but the code had an extra underscore: `:default__comparison_function`

added some tests to verify
